### PR TITLE
a spacing problem fix

### DIFF
--- a/creole/creole2html/parser.py
+++ b/creole/creole2html/parser.py
@@ -395,7 +395,7 @@ class CreoleParser:
 
     def _char_repl(self, groups):
         if self.text is None:
-            self.text = DocNode('text', self.cur, u"")
+            self.text = DocNode('text', self.cur, u" ")
         self.text.content += groups.get('char', u"")
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
When you declare a parser with blog_line_breaks=False you end up with words joined together where there is a line break.

For example the text:

these are some words
broken over a line

come out like:

<p>these are some wordsbroken over a line</p>


the attached fixes this.
