### PR TITLE
Support figure / image alignment

### DIFF
--- a/creole/rest2html/clean_writer.py
+++ b/creole/rest2html/clean_writer.py
@@ -164,6 +164,28 @@ class CleanHTMLTranslator(html4css1.HTMLTranslator, object):
     def depart_docinfo(self, node):
         self.body.append('</table>\n')
 
+    #__________________________________________________________________________
+    # Clean image:
+
+    depart_figure = _do_nothing
+
+    def visit_image(self, node):
+        super(CleanHTMLTranslator, self).visit_image(node)
+        if self.body[-1].startswith('<img'):
+            align = None
+
+            if 'align' in node:
+                # image with alignment
+                align = node['align']
+
+            elif node.parent.tagname == 'figure' and 'align' in node.parent:
+                # figure with alignment
+                align = node.parent['align']
+
+            if align:
+                self.body[-1] = self.body[-1].replace(' />', ' align="%s" />' % align)
+
+
 
 def rest2html(content, enable_exit_status=None, **kwargs):
     """

--- a/creole/tests/test_rest2html.py
+++ b/creole/tests/test_rest2html.py
@@ -148,6 +148,28 @@ class ReSt2HtmlTests(BaseCreoleTest):
             <hr width=50 size=10>
         """, raw_enabled=True)
 
+    def test_preserve_image_alignment(self):
+        self.assert_rest2html("""
+            Image alignment should be preserved.
+
+            .. image:: foo.png
+               :align: right
+        """, """
+            <p>Image alignment should be preserved.</p>
+            <img alt="foo.png" src="foo.png" align="right" />
+        """)
+
+    def test_preserve_figure_alignment(self):
+        self.assert_rest2html("""
+            Image alignment should be preserved.
+
+            .. figure:: bar.png
+               :align: right
+        """, """
+            <p>Image alignment should be preserved.</p>
+            <img alt="bar.png" src="bar.png" align="right" />
+        """)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The default docutils rst2html renders image alignments using a css-class (and the css-definition in the document head).
The creole implementation strips away the css-class, so we have no alignment information left.

I've implemented a fix which puts the alignment information in the html `align` attribute of the `img` tag,
since I think using css is not the creole way.
It's not too beautiful but it works, better ideas are appreciated ;)

I didn't figure what to do with the cross conversion stuff, so i didn't do anything there.

On github, which seems to use creole's rest2html, image alignment currently does not work, as reported in github/markup#163 - it would be great to get this fixed :-)
