### PR TITLE
Fix "Undefined substitution referenced" error

### DIFF
--- a/creole/emitter/html2rest_emitter.py
+++ b/creole/emitter/html2rest_emitter.py
@@ -86,6 +86,8 @@ class ReStructuredTextEmitter(BaseEmitter):
         result = self.emit_children(node)
         if self._substitution_data:
             # add rest at the end
+            if not result.endswith("\n\n"):
+                 result += "\n\n"
             result += "%s\n\n" % self._get_block_data()
         return result
 

--- a/creole/tests/test_html2rest.py
+++ b/creole/tests/test_html2rest.py
@@ -71,6 +71,18 @@ class ReStTests(BaseCreoleTest):
             """
         )
 
+    def test_substitution_image_without_p(self):
+        self.assert_html2rest(
+            rest_string="""
+                |image.png|
+
+                .. |image.png| image:: /url/to/image.png
+            """,
+            html_string="""
+                <img src="/url/to/image.png" />
+            """
+        )
+
     def test_pre_code1(self):
         self.assert_html2rest(
             rest_string="""


### PR DESCRIPTION
Add an empty line before "_substitution_data" if not already present.

This commit passes the simplified test case added by this commit and fixes the error I was reporting in issue #26, but still the HTML file attached to issue #26 has some problems.
