### PR TITLE
Adding optional img size to creole2html and html2creole

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -47,7 +47,7 @@ For all functionality (and running the unittests) these modules are needed:
 Convert creole markup to html code:
 {{{
 >>> from creole import creole2html
->>> creole2html("This is **creole //markup//**")
+>>> creole2html(u"This is **creole //markup//**")
 u'<p>This is <strong>creole <i>markup</i></strong></p>\n'
 }}}
 

--- a/README.creole
+++ b/README.creole
@@ -47,7 +47,7 @@ For all functionality (and running the unittests) these modules are needed:
 Convert creole markup to html code:
 {{{
 >>> from creole import creole2html
->>> creole2html(u"This is **creole //markup//**")
+>>> creole2html("This is **creole //markup//**")
 u'<p>This is <strong>creole <i>markup</i></strong></p>\n'
 }}}
 

--- a/creole/__init__.py
+++ b/creole/__init__.py
@@ -42,6 +42,7 @@ def creole2html(markup_string, debug=False,
         parser_kwargs=None, emitter_kwargs=None,
         block_rules=None, blog_line_breaks=True,
         macros=None, verbose=None, stderr=None,
+        allow_img_size=False,
     ):
     """
     convert creole markup into html code
@@ -70,6 +71,7 @@ def creole2html(markup_string, debug=False,
         "macros": macros,
         "verbose": verbose,
         "stderr": stderr,
+        "allow_img_size": allow_img_size,
     }
     if emitter_kwargs is not None:
         warnings.warn("emitter_kwargs argument in creole2html would be removed in the future!", PendingDeprecationWarning)

--- a/creole/__init__.py
+++ b/creole/__init__.py
@@ -42,7 +42,7 @@ def creole2html(markup_string, debug=False,
         parser_kwargs=None, emitter_kwargs=None,
         block_rules=None, blog_line_breaks=True,
         macros=None, verbose=None, stderr=None,
-        allow_img_size=False,
+        strict=False,
     ):
     """
     convert creole markup into html code
@@ -71,7 +71,7 @@ def creole2html(markup_string, debug=False,
         "macros": macros,
         "verbose": verbose,
         "stderr": stderr,
-        "allow_img_size": allow_img_size,
+        "strict": strict,
     }
     if emitter_kwargs is not None:
         warnings.warn("emitter_kwargs argument in creole2html would be removed in the future!", PendingDeprecationWarning)
@@ -92,9 +92,13 @@ def parse_html(html_string, debug=False):
     return document_tree
 
 
-def html2creole(html_string, debug=False,
-        parser_kwargs=None, emitter_kwargs=None,
-        unknown_emit=None
+def html2creole(
+        html_string,
+        debug=False,
+        parser_kwargs=None,
+        emitter_kwargs=None,
+        unknown_emit=None,
+        strict=False,
     ):
     """
     convert html code into creole markup
@@ -109,6 +113,7 @@ def html2creole(html_string, debug=False,
 
     emitter_kwargs2 = {
         "unknown_emit": unknown_emit,
+        "strict": strict,
     }
     if emitter_kwargs is not None:
         warnings.warn("emitter_kwargs argument in html2creole would be removed in the future!", PendingDeprecationWarning)

--- a/creole/emitter/creol2html_emitter.py
+++ b/creole/emitter/creol2html_emitter.py
@@ -102,9 +102,10 @@ class HtmlEmitter(object):
     Generate HTML output for the document
     tree consisting of DocNodes.
     """
-    def __init__(self, root, macros=None, verbose=None, stderr=None):
-        self.root = root
+    def __init__(self, root, macros=None, verbose=None, stderr=None, \
+        allow_img_size=False):
 
+        self.root = root
 
         if callable(macros) == True:
             # was a DeprecationWarning in the past
@@ -142,6 +143,8 @@ class HtmlEmitter(object):
             self.stderr = sys.stderr
         else:
             self.stderr = stderr
+
+        self.allow_img_size = allow_img_size
 
     def get_text(self, node):
         """Try to emit whatever text is in the node."""
@@ -271,7 +274,17 @@ class HtmlEmitter(object):
     def image_emit(self, node):
         target = node.content
         text = self.attr_escape(self.get_text(node))
-
+        if self.allow_img_size:
+            try:
+                if "|" in text:
+                    title, size_str = text.split("|", 1)
+                    w_str, h_str = size_str.split(",", 1)
+                    width = int(w_str.strip())
+                    height = int(h_str.strip())
+                    return '<img src="%s" title="%s" alt="%s" width="%s" height="%s" />' % (
+                        self.attr_escape(target), title, title, width, height)
+            except:
+                pass
         return '<img src="%s" title="%s" alt="%s" />' % (
             self.attr_escape(target), text, text)
 

--- a/creole/emitter/creol2html_emitter.py
+++ b/creole/emitter/creol2html_emitter.py
@@ -102,8 +102,7 @@ class HtmlEmitter(object):
     Generate HTML output for the document
     tree consisting of DocNodes.
     """
-    def __init__(self, root, macros=None, verbose=None, stderr=None, \
-        allow_img_size=False):
+    def __init__(self, root, macros=None, verbose=None, stderr=None, strict=False):
 
         self.root = root
 
@@ -144,7 +143,7 @@ class HtmlEmitter(object):
         else:
             self.stderr = stderr
 
-        self.allow_img_size = allow_img_size
+        self.strict = strict
 
     def get_text(self, node):
         """Try to emit whatever text is in the node."""
@@ -274,11 +273,13 @@ class HtmlEmitter(object):
     def image_emit(self, node):
         target = node.content
         text = self.attr_escape(self.get_text(node))
-        if self.allow_img_size:
+        if not self.strict:
             try:
                 if "|" in text:
                     title, size_str = text.split("|", 1)
-                    w_str, h_str = size_str.split(",", 1)
+                    if not title:
+                        title = target
+                    w_str, h_str = size_str.split("x", 1)
                     width = int(w_str.strip())
                     height = int(h_str.strip())
                     return '<img src="%s" title="%s" alt="%s" width="%s" height="%s" />' % (

--- a/creole/emitter/html2creole_emitter.py
+++ b/creole/emitter/html2creole_emitter.py
@@ -22,11 +22,9 @@ class CreoleEmitter(BaseEmitter):
     Build from a document_tree (html2creole.parser.HtmlParser instance) a
     creole markup text.
     """
-    def __init__(self, *args, **kwargs):
-        self.strict = kwargs["strict"]
-        del kwargs["strict"]
-
-        super(CreoleEmitter, self).__init__(*args, **kwargs)
+    def __init__(self, document_tree, strict=False, *args, **kwargs):
+        self.strict = strict
+        super(CreoleEmitter, self).__init__(document_tree, *args, **kwargs)
 
         self.table_head_prefix = "= "
         self.table_auto_width = True
@@ -117,7 +115,6 @@ class CreoleEmitter(BaseEmitter):
         alt = node.attrs.get("alt", "")
         width = node.attrs.get("height", None)
         height = node.attrs.get("width", None)
-        print("strict", self.strict)
         if len(alt) > len(title): # Use the longest one
             text = alt
         else:

--- a/creole/emitter/html2creole_emitter.py
+++ b/creole/emitter/html2creole_emitter.py
@@ -23,6 +23,9 @@ class CreoleEmitter(BaseEmitter):
     creole markup text.
     """
     def __init__(self, *args, **kwargs):
+        self.strict = kwargs["strict"]
+        del kwargs["strict"]
+
         super(CreoleEmitter, self).__init__(*args, **kwargs)
 
         self.table_head_prefix = "= "
@@ -112,6 +115,9 @@ class CreoleEmitter(BaseEmitter):
 
         title = node.attrs.get("title", "")
         alt = node.attrs.get("alt", "")
+        width = node.attrs.get("height", None)
+        height = node.attrs.get("width", None)
+        print("strict", self.strict)
         if len(alt) > len(title): # Use the longest one
             text = alt
         else:
@@ -119,6 +125,10 @@ class CreoleEmitter(BaseEmitter):
 
         if text == "": # Use filename as picture text
             text = posixpath.basename(src)
+
+        if not self.strict:
+            if width and height:
+                return "{{%s|%s|%sx%s}}" % (src, text, width, height)
 
         return "{{%s|%s}}" % (src, text)
 

--- a/creole/tests/test_creole2html.py
+++ b/creole/tests/test_creole2html.py
@@ -210,6 +210,8 @@ class TestCreole2html(BaseCreoleTest):
             warnings.warn("Skip test, because 'pygments' is not installed.")
             return
 
+        # due to https://bitbucket.org/birkenfeld/pygments-main/issues/1254/empty-at-the-begining-of-the-highlight
+        # an empty <span></span> is now part of pygments output
         self.assert_creole2html(r"""
             Here a simple code macro test:
             <<code ext=".py">>
@@ -218,8 +220,8 @@ class TestCreole2html(BaseCreoleTest):
             <</code>>
             """, """
             <p>Here a simple code macro test:</p>
-            <div class="pygments"><pre><span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">):</span><br />
-                <span class="k">print</span><span class="p">(</span><span class="s">&#39;hello world&#39;</span><span class="p">)</span><br />
+            <div class="pygments"><pre><span></span><span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">xrange</span><span class="p">(</span><span class="mi">10</span><span class="p">):</span><br />
+                <span class="k">print</span><span class="p">(</span><span class="s1">&#39;hello world&#39;</span><span class="p">)</span><br />
             </pre></div><br />
             """,
             macros={'code': example_macros.code}
@@ -746,6 +748,32 @@ class TestCreole2htmlMarkup(BaseCreoleTest):
             <img src="/path1/path2/foobar2.jpg" title="/path1/path2/foobar2.jpg" alt="/path1/path2/foobar2.jpg" /><br />
             <img src="/path1/path2/foobar3.jpg" title="foobar3.jpg" alt="foobar3.jpg" /></p>
         """)
+
+    def test_image_with_size(self):
+        """ test image tag with size dimention (good and bad) """
+        self.assert_creole2html(r"""
+            {{/path1/path2/foobar3.jpg|foo|160x90}}
+            {{/path1/path2/foobar3.jpg|foo| 160 x 90 }}
+            {{/path1/path2/foobar3.jpg|foo|160}}
+            {{/path1/path2/foobar3.jpg||160x90}}
+            {{/path1/path2/foobar3.jpg|foo|}}
+        """, """
+            <p><img src="/path1/path2/foobar3.jpg" title="foo" alt="foo" width="160" height="90" /><br />
+            <img src="/path1/path2/foobar3.jpg" title="foo" alt="foo" width="160" height="90" /><br />
+            <img src="/path1/path2/foobar3.jpg" title="foo|160" alt="foo|160" /><br />
+            <img src="/path1/path2/foobar3.jpg" title="/path1/path2/foobar3.jpg" alt="/path1/path2/foobar3.jpg" width="160" height="90" /><br />
+            <img src="/path1/path2/foobar3.jpg" title="foo|" alt="foo|" /></p>
+        """)
+
+    def test_image_with_size_strict(self):
+        """ test image tag with size dimention (good and bad) """
+        self.assert_creole2html(r"""
+            {{/path1/path2/foobar3.jpg|foo|160x90}}
+            {{/path1/path2/foobar3.jpg|foo|160}}
+        """, """
+            <p><img src="/path1/path2/foobar3.jpg" title="foo|160x90" alt="foo|160x90" /><br />
+            <img src="/path1/path2/foobar3.jpg" title="foo|160" alt="foo|160" /></p>
+        """, strict=True)
 
     def test_image_unknown_extension(self):
         self.assert_creole2html(r"""

--- a/creole/tests/test_cross_compare_all.py
+++ b/creole/tests/test_cross_compare_all.py
@@ -551,6 +551,10 @@ class CrossCompareTests(BaseCreoleTest):
                 """,
             html_string="""
                 <table>
+                <colgroup>
+                <col width="50%" />
+                <col width="50%" />
+                </colgroup>
                 <tr><th>Headline 1</th>
                 <th>Headline 2</th>
                 </tr>

--- a/creole/tests/test_cross_compare_rest.py
+++ b/creole/tests/test_cross_compare_rest.py
@@ -178,6 +178,9 @@ class CrossCompareReStTests(BaseCreoleTest):
             html_string="""
                 <p>before table.</p>
                 <table>
+                <colgroup>
+                <col width="100%" />
+                </colgroup>
                 <tr><td>table item</td>
                 </tr>
                 </table>
@@ -196,6 +199,9 @@ class CrossCompareReStTests(BaseCreoleTest):
             """,
             html_string="""
                 <table>
+                <colgroup>
+                <col width="100%" />
+                </colgroup>
                 <tr><td><a href="foo/bar">table item</a></td>
                 </tr>
                 </table>
@@ -213,6 +219,9 @@ class CrossCompareReStTests(BaseCreoleTest):
             """,
             html_string="""
                 <table>
+                <colgroup>
+                <col width="100%" />
+                </colgroup>
                 <tr><td>foo <a href="foo/bar">table item</a> bar</td>
                 </tr>
                 </table>
@@ -233,6 +242,9 @@ class CrossCompareReStTests(BaseCreoleTest):
             """,
             html_string="""
                 <table>
+                <colgroup>
+                <col width="100%" />
+                </colgroup>
                 <tr><td><ul>
                 <li>foo <a href="foo/bar/1/">table item 1</a> bar 1</li>
                 </ul>
@@ -263,6 +275,9 @@ class CrossCompareReStTests(BaseCreoleTest):
             """,
             html_string="""
                 <table>
+                <colgroup>
+                <col width="100%" />
+                </colgroup>
                 <tr><td><a href="foo/bar/1/">table item 1</a></td>
                 </tr>
                 <tr><td><a href="foo/bar/2/">table item 2</a></td>
@@ -288,6 +303,9 @@ class CrossCompareReStTests(BaseCreoleTest):
             """,
             html_string="""
                 <table>
+                <colgroup>
+                <col width="100%" />
+                </colgroup>
                 <tr><td>this is <a href="foo/bar/">foo bar</a> first time.</td>
                 </tr>
                 <tr><td>and here <a href="foo/bar/">foo bar</a> again.</td>
@@ -311,6 +329,9 @@ class CrossCompareReStTests(BaseCreoleTest):
             """,
             html_string="""
                 <table>
+                <colgroup>
+                <col width="100%" />
+                </colgroup>
                 <tr><td>this is <a href="foo/bar/">foo bar</a> first time.</td>
                 </tr>
                 </table>
@@ -332,6 +353,9 @@ class CrossCompareReStTests(BaseCreoleTest):
             """,
             html_string="""
                 <table>
+                <colgroup>
+                <col width="100%" />
+                </colgroup>
                 <tr><td>first <img alt="image" src="/picture.png" /> here</td>
                 </tr>
                 <tr><td>second <img alt="image" src="/picture.png" /> there</td>
@@ -357,6 +381,9 @@ class CrossCompareReStTests(BaseCreoleTest):
             """,
             html_string="""
                 <table>
+                <colgroup>
+                <col width="100%" />
+                </colgroup>
                 <tr><td>a <img alt="same" src="/image.png" /> image here</td>
                 </tr>
                 <tr><td>a <a href="/url/foo/">same</a> link there</td>

--- a/creole/tests/test_html2creole.py
+++ b/creole/tests/test_html2creole.py
@@ -279,6 +279,30 @@ class TestHtml2CreoleMarkup(BaseCreoleTest):
             9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="data uri should be disallowed" /></p>
         """)
 
+    def test_image_with_size(self):
+        """ test image tag with sizes """
+        self.assert_html2creole(r"""
+            {{foobar1.jpg|foobar1.jpg}}
+            {{foobar2.jpg|foobar2.jpg|90x160}}
+            {{foobar3.jpg|foobar3.jpg}}
+        """, """
+            <p><img src="foobar1.jpg" /><br />
+            <img src="foobar2.jpg" width="160" height="90" /><br />
+            <img src="foobar3.jpg" width="160" /></p>
+        """)
+
+    def test_image_with_size_strict(self):
+        """ test image tag with sizes """
+        self.assert_html2creole(r"""
+            {{foobar1.jpg|foobar1.jpg}}
+            {{foobar2.jpg|foobar2.jpg}}
+            {{foobar3.jpg|foobar3.jpg}}
+        """, """
+            <p><img src="foobar1.jpg" /><br />
+            <img src="foobar2.jpg" width="160" height="90" /><br />
+            <img src="foobar3.jpg" width="160" /></p>
+        """, strict=True)
+
     def test_non_closed_br(self):
         self.assert_html2creole(r"""
             one

--- a/creole/tests/test_rest2html.py
+++ b/creole/tests/test_rest2html.py
@@ -45,6 +45,10 @@ class ReSt2HtmlTests(BaseCreoleTest):
             +------------+------------+
         """, """
             <table>
+            <colgroup>
+            <col width="50%" />
+            <col width="50%" />
+            </colgroup>
             <tr><th>Headline 1</th>
             <th>Headline 2</th>
             </tr>

--- a/creole/tests/utils/base_unittest.py
+++ b/creole/tests/utils/base_unittest.py
@@ -104,10 +104,12 @@ class BaseCreoleTest(MarkupTest):
         else:
             f(member, container, *args, **kwargs)
 
-    def assert_creole2html(self, raw_creole, raw_html, \
+    def assert_creole2html(
+            self, raw_creole, raw_html,
             strip_lines=False, debug=False,
             parser_kwargs={}, emitter_kwargs={},
             block_rules=None, blog_line_breaks=True, macros=None, verbose=None, stderr=None,
+            strict=False,
         ):
         """
         compare the generated html code from the markup string >creole_string<
@@ -133,6 +135,7 @@ class BaseCreoleTest(MarkupTest):
             markup_string, debug,
             block_rules=block_rules, blog_line_breaks=blog_line_breaks,
             macros=macros, verbose=verbose, stderr=stderr,
+            strict=strict,
         )
         if debug:
             self._debug_text("assert_creole2html() creole2html", out_string)
@@ -145,9 +148,15 @@ class BaseCreoleTest(MarkupTest):
         # compare
         self.assertEqual(out_string, html_string, msg="creole2html")
 
-    def assert_html2creole2(self, creole, html, debug=False, unknown_emit=None):
+    def assert_html2creole2(self, creole, html,
+            debug=False, 
+            unknown_emit=None,
+            strict=False,
+        ):
         # convert html code into creole markup
-        out_string = html2creole(html, debug, unknown_emit=unknown_emit)
+        out_string = html2creole(
+            html, debug, unknown_emit=unknown_emit, strict=strict
+        )
         if debug:
             self._debug_text("assert_html2creole() html2creole", out_string)
 
@@ -159,7 +168,8 @@ class BaseCreoleTest(MarkupTest):
                 # OLD API:
                 parser_kwargs={}, emitter_kwargs={},
                 # html2creole:
-                unknown_emit=None
+                unknown_emit=None,
+                strict=False,
         ):
         """
         Compare the genereted markup from the given >raw_html< html code, with
@@ -182,8 +192,7 @@ class BaseCreoleTest(MarkupTest):
         html = self._prepare_text(raw_html)
         assert isinstance(html, TEXT_TYPE)
 
-        self.assert_html2creole2(creole, html, debug, unknown_emit)
-
+        self.assert_html2creole2(creole, html, debug, unknown_emit, strict)
 
     def cross_compare_creole(self, creole_string, html_string,
                         strip_lines=False, debug=False,


### PR DESCRIPTION
I dropped the `allow_image_size` as suggested, but was still concerned about users who would expect a strict interpretation of creole. So, instead, I added a generic `strict=False`. So, the routines will default to allowing this (and possibly other future) extensions. But users wanting a strict interpretation can purposely pass that as a parameter.

But, I'm happy to remove `strict` if you really don't want it.

Additions to test have been made. I also updated to the `<<code>>` macro test to reflect `pygments` library's current behavior.

If and after a pull is made, I'll update the wiki doc to reflect the new parameter and the extension to img.