### PR TITLE
Update creol2html_rules.py

### DIFF
--- a/creole/parser/creol2html_rules.py
+++ b/creole/parser/creol2html_rules.py
@@ -51,7 +51,7 @@ class InlineRules(object):
 #        ''' % proto
 
     # image tag
-    image = r'''(?i)(?P<image>
+    image = r'''(?P<image>
             {{
             (?P<image_target>.+?) \s*
             (\| \s* (?P<image_text>.+?) \s*)?


### PR DESCRIPTION
(?i) is re.IGNORECASE
The image tag doesn't contain anything that must match case-insensitive. So it can be removed, to fix: #31