### PR TITLE
Replace poetry with poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ update_markdown_readme = "creole.setup_utils:update_creole_markdown_readme"
 publish = "creole.publish:publish"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 
 [tool.darker]


### PR DESCRIPTION
In [nixpkgs](https://github.com/NixOS/nixpkgs), we build Python packages using [build](https://pypa-build.readthedocs.io/en/stable/) instead of poetry, and so we only need to use the more lightweight poetry-core as the PEP 517 build backend.